### PR TITLE
Fix `neil new` README command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can use a specific commit from this repo using `garden init --template io.gi
 
 If you want you can also use it with [neil](https):
 
-    $ neil new io.github.nextjournal/garden-template-clerk
+    $ neil new io.github.nextjournal/garden-template-clerk mycoolproject
 
 or with
 


### PR DESCRIPTION
Hi!

When I run the `neil new` command from the README, I just see the Neil helptext:

```
$ neil new io.github.nextjournal/garden-template-clerk

Usage: neil new [template] [name] [target-dir] [options]

Runs the org.corfield.new/create function from deps-new.

All of the deps-new options can be provided as CLI options:

https://github.com/seancorfield/deps-new/blob/develop/doc/options.md

Both built-in and external templates are supported. Built-in templates use
unqualified names (e.g. scratch) whereas external templates use fully-qualified
names (e.g. io.github.kit/kit-clj).

The provided built-in templates are:

    app
    lib
    pom
    scratch
    template

If an external template is provided, the babashka.deps/add-deps function will be
called automatically before running org.corfield.new/create. The deps for the
template are inferred automatically from the template name. The following
options can be used to control the add-deps behavior:

  --local/root
    Override the :deps map to use the provided :local/root path.

  --git/url
    Override the :git/url in the :deps map. If no URL is provided, a template
    name starting with io.github or com.github is expected and the URL will
    point to GitHub.

  --git/tag
    Override the :git/tag in the :deps map. If no SHA or tag is provided, the
    latest tag from the default branch of :git/url will be used.

  --sha
  --git/sha
    Override the :git/sha in the :deps map. If no SHA or tag is provided, the
    latest tag from the default branch of :git/url will be used.

  --latest-sha
    Override the :git/sha in the :deps map with the latest SHA from the
    default branch of :git/url.

Examples:
  neil new scratch foo --overwrite
  neil new io.github.rads/neil-new-test-template foo2 --latest-sha
```

Adding project name appears to work:

```
$ neil new io.github.nextjournal/garden-template-clerk starting-clojure
Cloning: https://github.com/nextjournal/garden-template-clerk
Checking out: https://github.com/nextjournal/garden-template-clerk at a46ab6eaa740bd7b1df6a628744073090bc86b0b
Creating project from io.github.nextjournal/garden-template-clerk in starting-clojure
```

This could probably be clearer from the `neil new` helptext

    Usage: neil new [template] [name] [target-dir] [options]

doesn't make it easy to understand which parameters are optional, and which are required.